### PR TITLE
fix: add missing treesitter namespace group

### DIFF
--- a/lua/blue-moon.lua
+++ b/lua/blue-moon.lua
@@ -227,6 +227,7 @@ local plugin_syntax = {
   ['@label']                = { fg = cyan_dark, italic = true },
   ['@debug']                = { fg = cyan_dark, italic = true },
   ['@include']              = { fg = cyan_dark },
+  ['@namespace']            = { fg = yellow },
 
   ['@operator'] = { fg = cyan },
   ['@comment']  = { fg = fg_dark, italic = true },


### PR DESCRIPTION
Hi, 
Highlighting for PHP namespaces broke for me, I fixed it by adding a colour for the `@namespace` treesitter highlight group.
Before:
![image](https://user-images.githubusercontent.com/15250778/206234789-d07b8e68-6197-4c44-bd37-8a717713bad6.png)
After:
![image](https://user-images.githubusercontent.com/15250778/206235006-2bb85742-ea19-45c3-b444-93d3364483ad.png)
